### PR TITLE
fix apigw gateway replacement warning prompt

### DIFF
--- a/lib/jets/cfn/resource/api_gateway/rest_api/logical_id.rb
+++ b/lib/jets/cfn/resource/api_gateway/rest_api/logical_id.rb
@@ -17,7 +17,7 @@ class Jets::Cfn::Resource::ApiGateway::RestApi
 
     def auto_replace_prompt
       return if ENV['JETS_API_AUTO_REPLACE']
-      return unless ARGV[0] == "deploy"
+      return unless Jets::Command.original_cli_command == "deploy"
       case Jets.config.api.auto_replace
       when nil
         puts message.routes_changed

--- a/lib/jets/cfn/resource/s3/jets_bucket.rb
+++ b/lib/jets/cfn/resource/s3/jets_bucket.rb
@@ -53,7 +53,7 @@ module Jets::Cfn::Resource::S3
         begin
           resp = cfn.describe_stacks(stack_name: Jets::Names.parent_stack_name)
         rescue Aws::CloudFormation::Errors::ValidationError => e
-          if e.message.include?('does not exist') && ARGV[0] == 'build' # jets build
+          if e.message.include?('does not exist') && Jets::Command.original_cli_command == 'build' # jets build
             return "no-bucket-yet" # for jets build without s3 bucket yet
           else
             raise

--- a/lib/jets/command.rb
+++ b/lib/jets/command.rb
@@ -17,6 +17,8 @@ module Jets
 
     HELP_MAPPINGS = %w(-h -? --help)
 
+    cattr_accessor :original_cli_command
+
     class << self
       def hidden_commands # :nodoc:
         @hidden_commands ||= []

--- a/lib/jets/command/base.rb
+++ b/lib/jets/command/base.rb
@@ -98,6 +98,7 @@ module Jets
             self.full_namespace = full_namespace # store for help. clean:log => log
           end
 
+          Jets::Command.original_cli_command = command
           dispatch(command, args.dup, nil, config)
         end
 


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fix the prompt that warns user that the APIGW Rest API will be replaced and a new endpoint will be created. This was accidentally broken in Jets 5 as part of the command CLI restructuring.

## Context

Related https://github.com/rubyonjets/jets/issues/391

## How to Test

I hacked the Routes changed? method to return true in the gem to reproduce and it prompts correctly.

## Version Changes

Patch