### PR TITLE
Replace puts with Jets.logger.info in jobs

### DIFF
--- a/lib/jets/job/base.rb
+++ b/lib/jets/job/base.rb
@@ -38,7 +38,7 @@ module Jets::Job
           call = Jets::Commands::Call::Caller.new(function_name, JSON.dump(event), invocation_type: "Event")
           call.run
         else
-          puts "INFO: Not on AWS Lambda. In local mode perform_later executes the job with perform_now instead."
+          Jets.logger.info "INFO: Not on AWS Lambda. In local mode perform_later executes the job with perform_now instead."
           perform_now(meth, event, context)
         end
       end


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

When doing rspec in local, one message keeps on showing: "INFO: Not on AWS Lambda. In local mode perform_later executes the job with perform_now instead.". This is annoying and messes with formatting of the test results. 
I replaced puts statement with Jets.logger.info which probably should be done in all other places, but I'm trying to keep this PR short and on point.

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

## How to Test

Run rspec of any project that calls job with `perform_later`. If you don't see a message "INFO: Not on AWS Lambda. In local mode perform_later executes the job with perform_now instead.", this PR's job is done.

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->

