### PR TITLE
improve cli usage invalid command and options handling

### DIFF
--- a/lib/jets/command/base.rb
+++ b/lib/jets/command/base.rb
@@ -98,8 +98,12 @@ module Jets
             self.full_namespace = full_namespace # store for help. clean:log => log
           end
 
-          Jets::Command.original_cli_command = command
           dispatch(command, args.dup, nil, config)
+        rescue Thor::InvocationError => e
+          puts e.message.color(:red) # message already has ERROR prefix
+          self.full_namespace = full_namespace # store for help. clean:log => log
+          dispatch("help", [], nil, config)
+          exit 1
         end
 
         def printing_commands

--- a/lib/jets/command/rake_decorate.rb
+++ b/lib/jets/command/rake_decorate.rb
@@ -1,0 +1,38 @@
+module Jets::Command
+  module RakeDecorate
+    # Decorate this method because this does not get called until runtime.
+    # It's "lazy loaded" so we can avoid the Rails const being defined in general.
+    def [](task_name, scopes=nil)
+      super # => Rake::TaskManager#[]
+    rescue RuntimeError => e
+      # We require dummy/rails since this time because all the rake tasks have been loaded
+      # and we need to load dummy/rails to get the database configurations. Normally,
+      # we do not want to require dummy/rails because it defines the Rails.
+      # However, a "command not found" error, more accurately,
+      # a "rake task not found" error, has already been encountered.
+      # Also:
+      # require "dummy/rails" to prevent another error.
+      #   from lib/active_record/railties/databases.rake
+      #
+      #   NoMethodError: undefined method `env' for Rails:Module (NoMethodError)
+      #     database_configs = ActiveRecord::DatabaseConfigurations.new(databases).configs_for(env_name: Rails.env)
+      #
+      require "jets/overrides/dummy/rails"
+
+      # Original error message from rake is something like this
+      #
+      #   Don't know how to build task 'foo:bar' (See the list of available tasks with `jets --tasks`)
+      #
+      # With an ugly backtrace.
+      # We override the error message to be more user friendly.
+      #
+      # All of that in order for
+      #   jets foo:bar
+      # to show a pretty error message.
+      $stderr.puts "ERROR: Could not find command: #{task_name.inspect}".color(:red)
+      require "jets/commands/help/help_command"
+      Jets::Command::HelpCommand.new.help
+      exit 1
+    end
+  end
+end


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Improve the cli usage so that it provides a friendly error and usage message when user:

* provides invalid non-existent command 
* provides invalid options for the command

Had to jump through some hoops and decorate Rake::TaskManager in order to lazy load the commands for the help usage message without loading the Rails const.

## Context

N/A

## How to Test

These commands should sure friendly error and usage message

    jets console --foo
    jets foo:bar

Also, should do regression test and make sure other commands still work. Examples:

    jets about
    jets console
    jets deploy
    jets server

## Version Changes

Patch