### PR TITLE
remove need for sprockets-jets dependency

### DIFF
--- a/lib/jets/builders/code_builder.rb
+++ b/lib/jets/builders/code_builder.rb
@@ -131,6 +131,7 @@ module Jets::Builders
     # We do not want to grab this as part of the live request because it is slow.
     def store_s3_base_url
       return if Jets.config.mode == "job"
+      return unless gemfile_include?("sprockets-jets")
       write_s3_base_url("#{stage_area}/code/config/s3_base_url.txt")
     end
 
@@ -192,9 +193,7 @@ module Jets::Builders
         puts "Skip compiling assets".color(:yellow) # useful for debugging
         return true
       end
-      return true if Jets.config.mode == "job"
-      return true unless Jets.config.respond_to?(:assets)
-      Jets.config.assets.enable_webpack
+      Jets.config.mode == "job"
     end
 
     # Different url for these. Examples:


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Allow jets applications to deploy without [sprockets-jets](https://github.com/rubyonjets/sprockets-jets). This can be useful for API projects that do not serve assets. This allows [jets deploy](https://docs.rubyonjets.com/reference/jets-deploy/) to work when users remove the `sprockets-jets` from their Gemfile because they don't need it.

Note: There's actual use-cases for API projects that do serve assets. Actually, I have an API app that serves javascript and stylesheet assets.  Going to leave the `sprockets-jets` in API mode for the `jets new --mode api` generator.

## Context

Related #681

## How to Test

Remove `sprockets-jets` from `Gemfile` and run:

   jets deploy

## Version Changes

Patch