### PR TITLE
do not include sprockets-jets in new app generator for api mode

### DIFF
--- a/lib/jets/builders/code_builder.rb
+++ b/lib/jets/builders/code_builder.rb
@@ -232,7 +232,7 @@ module Jets::Builders
       # Checking this way because when using jets standalone for Afterburner mode we don't want to run into
       # bundler gem collisions.  TODO: figure out the a better way to handle the collisions.
       lines = IO.readlines("#{Jets.root}/Gemfile")
-      lines.detect { |l| l =~ /#{name}/ && l !~ /\s.*#/ }
+      lines.detect { |l| l =~ /gem ['"]#{name}/ && l !~ /^\s*?#/ }
     end
 
     # Cleans out non-cached files like code-*.zip in Jets.build_root

--- a/lib/jets/cfn/upload.rb
+++ b/lib/jets/cfn/upload.rb
@@ -138,6 +138,9 @@ module Jets::Cfn
     # If only max_age is provided, then we'll generate a cache_control header.
     # Using max_age is the shorter and simply way of setting the cache_control header.
     def cache_control
+      # default when sprockets-jets not installed
+      return "public, max-age=3600" unless Jets.config.respond_to?(:assets)
+
       cache_control = Jets.config.assets.cache_control
       unless cache_control
         max_age = Jets.config.assets.max_age # defaults to 3600 in jets/application.rb

--- a/lib/jets/generators/overrides/app/templates/Gemfile.tt
+++ b/lib/jets/generators/overrides/app/templates/Gemfile.tt
@@ -2,9 +2,12 @@ source "https://rubygems.org"
 
 gem "jets", "~> <%= Jets::VERSION %>"
 
+<%- if options[:mode] == 'html'-%>
+gem "sprockets-jets"
+<% end -%>
+
 <%- if options[:mode] != 'job' && !options[:database].nil? -%>
 <%= database_gemfile_entry %>
-gem "sprockets-jets"
 <%- end -%>
 <%- if options[:mode] == 'html' -%>
 gem "importmap-jets"


### PR DESCRIPTION
cache control default when sprockets-jets not installed

<!-- This is a 🐞 bug fix. -->
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Do include sprockets-jets by default in the `jets new --mode api` generator. This allows jets avoids the `jets assets:compile` step. 

## Context

#686

## How to Test

    jets new demo --mode api
    cd demo
    # Check that sprockets-jets is not in the Gemfile
    jets deploy

## Version Changes

Patch