### PR TITLE
fix sqs_queue output url camelcase name

### DIFF
--- a/lib/jets/lambda/dsl.rb
+++ b/lib/jets/lambda/dsl.rb
@@ -245,13 +245,11 @@ module Jets::Lambda::Dsl
       end
 
       def ref(name)
-        name = name.is_a?(Symbol) ? name.to_s.camelize : name
-        "!Ref #{name}"
+        "!Ref #{name.to_s.camelize}"
       end
 
       def sub(value)
-        value = value.is_a?(Symbol) ? value.to_s.camelize : value
-        "!Sub #{value}"
+        "!Sub #{value.to_s.camelize}"
       end
 
       # meth is a Symbol

--- a/lib/jets/stack/main/dsl/sqs.rb
+++ b/lib/jets/stack/main/dsl/sqs.rb
@@ -4,7 +4,7 @@ module Jets::Stack::Main::Dsl
       # props[:queue_name] ||= id.to_s # comment out to allow CloudFormation to generate name
       resource(id, "AWS::SQS::Queue", props)
       output(id, Value: get_att("#{id}.Arn")) # normal !Ref returns the sqs url the ARN is useful for nested stacks depends_on
-      output("#{id}Url", ref(id)) # useful for Stack.lookup method. IE: List.lookup(:waitlist_url)
+      output("#{id}_url", ref(id)) # useful for Stack.lookup method. IE: List.lookup(:waitlist_url)
     end
   end
 end


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Using `ref("my_tasks")` with a **String** does not camelize the logical id. Only **Symbol** are camelized. This results in the CloudFormation deploy failing with code like this:

app/jobs/waiter_job.rb

```ruby
class WaiterJob < ApplicationJob
  depends_on "list"
  class_timeout 30 # less than to equal to the default queue timeout

  # sqs_event "hello-queue"
  sqs_event ref("my_tasks")
  def dig
    puts "done digging"
  end
end
```

app/shared/resources/list.rb

```ruby
class List < Jets::Stack
  sqs_queue("my_tasks", message_retention_period: 3600, visibility_timeout: 120)
end
```

This adjusts the `ref` method so that it'll camelize String or Symbol, so the code above deploy successfully.

## Context

https://community.boltops.com/t/ruby-on-jets-5-0-release-improvements-galore/1123/6?u=tung


## How to Test

Deploy this project.

https://github.com/tongueroo/demo-sqs-queue-ref

## Version Changes

Patch
