### PR TITLE
make iam_policy additive to default_iam_policy for event

### DIFF
--- a/lib/jets/job/dsl/dynamodb_event.rb
+++ b/lib/jets/job/dsl/dynamodb_event.rb
@@ -7,10 +7,11 @@ module Jets::Job::Dsl
       stream_arn = full_dynamodb_stream_arn(table_name)
       default_iam_policy = default_dynamodb_stream_policy(stream_arn)
 
-      # Create iam policy allows access to queue
-      # Allow disabling in case use wants to add permission application-wide and not have extra IAM policy
-      iam_policy_props = options.delete(:iam_policy) || @iam_policy || default_iam_policy
-      iam_policy(iam_policy_props) unless iam_policy_props == :disable
+      # Create iam policy allows access to dynamodb
+      iam_policy_option = [options.delete(:iam_policy)].compact.flatten
+      user_iam_policy = [@iam_policy].compact.flatten
+      iam_policy_props = iam_policy_option + user_iam_policy + [default_iam_policy]
+      iam_policy(iam_policy_props)
 
       props = options # by this time options only has EventSourceMapping properties
       default = {

--- a/lib/jets/job/dsl/kinesis_event.rb
+++ b/lib/jets/job/dsl/kinesis_event.rb
@@ -4,10 +4,11 @@ module Jets::Job::Dsl
       stream_arn = full_kinesis_stream_arn(stream_name)
       default_iam_policy = default_kinesis_stream_policy(stream_arn)
 
-      # Create iam policy allows access to queue
-      # Allow disabling in case use wants to add permission application-wide and not have extra IAM policy
-      iam_policy_props = options.delete(:iam_policy) || @iam_policy || default_iam_policy
-      iam_policy(iam_policy_props) unless iam_policy_props == :disable
+      # Create iam policy allows access to kinesis
+      iam_policy_option = [options.delete(:iam_policy)].compact.flatten
+      user_iam_policy = [@iam_policy].compact.flatten
+      iam_policy_props = iam_policy_option + user_iam_policy + [default_iam_policy]
+      iam_policy(iam_policy_props)
 
       props = options # by this time options only has EventSourceMapping properties
       default = {

--- a/lib/jets/job/dsl/sqs_event.rb
+++ b/lib/jets/job/dsl/sqs_event.rb
@@ -51,9 +51,10 @@ module Jets::Job::Dsl
       end
 
       # Create iam policy allows access to queue
-      # Allow disabling in case use wants to add permission application-wide and not have extra IAM policy
-      iam_policy_props = options.delete(:iam_policy) || @iam_policy || default_iam_policy
-      iam_policy(iam_policy_props) unless iam_policy_props == :disable
+      iam_policy_option = [options.delete(:iam_policy)].compact.flatten
+      user_iam_policy = [@iam_policy].compact.flatten
+      iam_policy_props = iam_policy_option + user_iam_policy + [default_iam_policy]
+      iam_policy(iam_policy_props)
 
       props = options # by this time options only has EventSourceMapping properties
       default = {


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Right now adding `iam_policy` will override the default policy that is associated with a Lambda Function handing an event.

IE: The SQS Event https://docs.rubyonjets.com/docs/events/sqs/

This feels like unexpected behavior. Instead, make the iam_policy **additive** to the default SQS IAM policy added by Jets.

## Context

Community Post: https://community.boltops.com/t/missing-sqs-messages/1126/3

Docs:

* https://docs.rubyonjets.com/docs/events/sqs/
* https://docs.rubyonjets.com/docs/events/kinesis/
* https://docs.rubyonjets.com/docs/events/dynamodb/

## How to Test

Example code snippet

app/jobs/courier_job.rb

```ruby
class CourierJob < ApplicationJob
  include Jets::AwsServices

  iam_policy("sns")
  sqs_event ref(:waitlist)
  def process
    Jets.logger.info("test sqs_event_payload: #{sqs_event_payload}")
  end
end
```

Build templates

    jets build 

Check template for IAM policy

    cat /tmp/jets/testapp/templates/app-courier_job.yml | yq '.Resources.CourierJobProcessIamPolicy'

Should see both: `sns:*` and the `sqs:...` permissions

```yaml
    Statement:
      - Action:
          - sns:*
        Effect: Allow
        Resource: "*"
      - Action:
          - sqs:ReceiveMessage
          - sqs:DeleteMessage
          - sqs:GetQueueAttributes
```

## Version Changes

Patch