### PR TITLE
cache Stack.lookup output in class memory

### DIFF
--- a/lib/jets/stack/output/lookup.rb
+++ b/lib/jets/stack/output/lookup.rb
@@ -6,7 +6,11 @@ class Jets::Stack::Output
       @stack_subclass = stack_subclass
     end
 
+    @@cache = {}
     def output(logical_id)
+      cache_key = "#{@stack_subclass}-#{logical_id}"
+      return @@cache[cache_key] if @@cache[cache_key]
+
       child_stack_id = @stack_subclass.to_s.camelize
 
       stack_arn = shared_stack_arn(child_stack_id)
@@ -14,7 +18,7 @@ class Jets::Stack::Output
       child = resp.stacks.first
       return unless child
 
-      output_value(child, logical_id)
+      @@cache[cache_key] = output_value(child, logical_id)
     end
 
     # Shared child stack arn


### PR DESCRIPTION


- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Reduces CloudFormation API calls to avoid `Rate exceeded Aws::CloudFormation::Errors::Throttling`

## Context

https://community.boltops.com/t/store-shared-resource-name-store/766

## How to Test

Sanity check with `List.lookup(:waitlist_url)` example.

## Version Changes

Patch