### PR TITLE
fix s3_event and change method to s3_event_payloads

### DIFF
--- a/lib/jets/job/helpers/s3_event_helper.rb
+++ b/lib/jets/job/helpers/s3_event_helper.rb
@@ -1,36 +1,38 @@
 module Jets::Job::Helpers
   module S3EventHelper
-    def s3_events
+    def s3_event_payloads
       messages = event["Records"].map do |record|
         record["Sns"]["Message"]
       end
-      message.map do |message|
+      messages.map do |message|
         h = JSON.load(message)
         ActiveSupport::HashWithIndifferentAccess.new(h)
       end
     end
 
-    def s3_events?
+    def s3_event_payloads?
       event["Records"]&.any? { |r| r.dig("Sns", "Message") }
     end
 
     def s3_objects
-      records = s3_event["Records"]
-      records.map do |record|
-        record["s3"]["object"]
-      end
+      s3_event_payloads.map do |payload|
+        records = payload["Records"]
+        records.map do |record|
+          record["s3"]["object"]
+        end
+      end.flatten
     end
 
     def s3_objects?
-      s3_event["Records"]&.any? { |r| r.dig("s3", "object") }
+      s3_event_payloads["Records"]&.any? { |r| r.dig("s3", "object") }
     end
 
     # Deprecated methods below
     def s3_event
       puts "WARN: s3_event is deprecated".color(:yellow)
       puts "It can possibly drop events when come in extremely fast."
-      puts "Use s3_events instead"
-      s3_events.first
+      puts "Use s3_event_payloads instead"
+      s3_event_payloads.first
     end
 
     def s3_object

--- a/spec/lib/jets/job/base_spec.rb
+++ b/spec/lib/jets/job/base_spec.rb
@@ -48,43 +48,28 @@ describe Jets::Job::Base do
     it "s3_event" do
       event = json_file("spec/fixtures/dumps/sns/s3_upload.json")
       job = HardJob.new(event, {}, :dig)
-      # uncomment to debug
-      # puts JSON.pretty_generate(job.event)
-      # puts JSON.pretty_generate(job.s3_event)
-      # puts JSON.pretty_generate(job.s3_object)
+      expect(job.s3_event_payloads.first).to include("Records")
 
-      expect(job.s3_event.key?("Records")).to be true
-
-      expect(job.s3_object.key?("key")).to be true
-      expect(job.s3_object[:key]).to eq "myfolder/subfolder/test.txt"
+      expect(job.s3_objects.first.key?("key")).to be true
+      expect(job.s3_objects.first[:key]).to eq "myfolder/subfolder/test.txt"
     end
   end
 
   context 'sns_event' do
-    it 'sns_event_payload' do
+    it 'sns_event_payloads' do
       event = json_file("spec/fixtures/dumps/sns/sns_event.json")
       job = HardJob.new(event, {}, :dig)
-      # uncomment to debug
-      # puts JSON.pretty_generate(job.event)
-      # puts JSON.pretty_generate(job.sns_event_payload)
-
-
-      expect(job.sns_event_payload.key?("body")).to be true
-      expect(job.sns_event_payload[:body]).to eq "This is a sns hard job"
+      expect(job.sns_event_payloads.first.key?("body")).to be true
+      expect(job.sns_event_payloads.first[:body]).to eq "This is a sns hard job"
     end
   end
 
   context 'sqs_event' do
-    it 'sns_event_payload' do
+    it 'sqs_event_payloads' do
       event = json_file("spec/fixtures/dumps/sqs/sqs_event.json")
       job = HardJob.new(event, {}, :dig)
-      # uncomment to debug
-      # puts JSON.pretty_generate(job.event)
-      # puts JSON.pretty_generate(job.sqs_event_payload)
-
-
-      expect(job.sqs_event_payload.key?("message")).to be true
-      expect(job.sqs_event_payload[:message]).to eq "This is a hard job"
+      expect(job.sqs_event_payloads.first.key?("message")).to be true
+      expect(job.sqs_event_payloads.first[:message]).to eq "This is a hard job"
     end
   end
 


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fix specs and rename method to `s3_event_payloads` to avoid conflict and also be consistent with other helpers.

## Context

https://github.com/rubyonjets/jets/pull/700

## How to Test

Run specs

## Version Changes

Patch