### PR TITLE
fix jets --version outside of jets project

### DIFF
--- a/lib/jets/commands/application/application_command.rb
+++ b/lib/jets/commands/application/application_command.rb
@@ -17,6 +17,12 @@ module Jets
       #   bundle exec jets application      => jets new --help
       #
       def perform(*args)
+        version_flags = %w[-v --version] & args
+        unless version_flags.empty?
+          puts "Jets #{Jets::VERSION}"
+          return
+        end
+
         # require lazily so that Rails constant is only defined within generators
         require "jets/generators/overrides/app/app_generator"
         override_exit_on_failure?


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Show `jets --version` correctly when outside of Jets project. Right now it shows the rails components version 🤣

## Context

Related #703

## How to Test

Run `jets --version` outside of jets project.

## Version Changes

Patch