### PR TITLE
permit YAML load of Date class

### DIFF
--- a/lib/jets/util/yamler.rb
+++ b/lib/jets/util/yamler.rb
@@ -3,12 +3,14 @@ class Jets::Util
   class Yamler
     class << self
       def load(text)
-        options = RUBY_VERSION =~ /^3/ ? {aliases: true} : {} # Ruby 3.0.0 deprecates aliases: true
+        options = { permitted_classes: [Date] }
+        options[:aliases] = true if RUBY_VERSION =~ /^3/ # Ruby 3.0.0 deprecates aliases: true
         YAML.load(text, **options)
       end
 
       def load_file(path)
-        options = RUBY_VERSION =~ /^3/ ? {aliases: true} : {} # Ruby 3.0.0 deprecates aliases: true
+        options = { permitted_classes: [Date] }
+        options[:aliases] = true if RUBY_VERSION =~ /^3/ # Ruby 3.0.0 deprecates aliases: true
         YAML.load_file(path, **options)
       end
     end


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix. 
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Upgrading an older Jets app from jets 3 to jets 4 and Ruby 3.2.2, I ran into an error with deploying related to YAML.load_file of generated CloudFormation templates for my Jets controllers. Some of the data looked like a Date and was crashing with the following:

```
Psych::DisallowedClass: Tried to load unspecified class: Date
  /Users/nate/.rbenv/versions/3.2.2/lib/ruby/3.2.0/psych/class_loader.rb:99:in `find'
  /Users/nate/.rbenv/versions/3.2.2/lib/ruby/3.2.0/psych/class_loader.rb:28:in `load'
  (eval):2:in `date'
```

This fixes the issue. I'm not sure what caused it to come up exactly, I'm guessing a gem dependency update.
