### PR TITLE
Fix Prewarming

### DIFF
--- a/engines/internal/app/jobs/jets/preheat_job.rb
+++ b/engines/internal/app/jobs/jets/preheat_job.rb
@@ -22,6 +22,7 @@ class Jets::PreheatJob < Jets::Job::Base
     }
   ])
 
+  rate(Jets.config.prewarm.rate) if Jets.config.prewarm.enable
   def warm
     options = call_options(event[:quiet])
     Jets::Preheat.warm_all(options)
@@ -31,7 +32,7 @@ class Jets::PreheatJob < Jets::Job::Base
   class << self
     # Can use this to prewarm post deploy
     def prewarm!
-      perform_now(:warn, quiet: true)
+      perform_now(:warm, quiet: true)
     end
   end
 

--- a/lib/jets/cfn/builder.rb
+++ b/lib/jets/cfn/builder.rb
@@ -136,6 +136,12 @@ module Jets::Cfn
           relative_path = path.sub("#{Jets.root}/", '') # rid of the Jets.root at beginning
           paths << relative_path
         end
+
+        if Jets.config.prewarm.enable
+          internal = File.expand_path("../internal", __dir__)
+          paths << "#{internal}/app/jobs/jets/preheat_job.rb"
+        end
+
         paths
       end
 

--- a/spec/lib/jets/cfn/builder_spec.rb
+++ b/spec/lib/jets/cfn/builder_spec.rb
@@ -17,6 +17,43 @@ describe Jets::Cfn::Builder do
       file_exist = File.exist?("/tmp/jets/demo/templates/jets-controller.yml")
       expect(file_exist).to be true
     end
+
+    context 'prewarm enabled' do
+      before { Jets.config.prewarm.enable = true }
+
+
+      it 'builds the preheat job template' do
+        allow(Jets).to receive(:s3_bucket).and_return("demo-test")
+        builder.build
+
+        preheat_job_file_path = "/tmp/jets/demo/templates/app-jets-preheat_job.yml"
+        file_exist = File.exist?(preheat_job_file_path)
+        expect(file_exist).to be true
+
+        template_hsh = YAML.load(File.read(preheat_job_file_path))
+        expect(template_hsh["Resources"].keys).to contain_exactly "JetsPreheatJobIamPolicy",
+                                                                  "JetsPreheatJobIamRole",
+                                                                  "JetsPreheatJobWarmEventsRule",
+                                                                  "JetsPreheatJobWarmLambdaFunction",
+                                                                  "JetsPreheatJobWarmPermission"
+
+        rule_schedule = template_hsh.dig("Resources", "JetsPreheatJobWarmEventsRule", "Properties", "ScheduleExpression")
+        expect(rule_schedule).to eq "rate(#{Jets.config.prewarm.rate})"
+      end
+    end
+
+    context 'prewarm disabled' do
+      before { Jets.config.prewarm.enable = false }
+
+      it 'does not build the preheat job template' do
+        allow(Jets).to receive(:s3_bucket).and_return("demo-test")
+        builder.build
+
+        preheat_job_file_path = "/tmp/jets/demo/templates/app-jets-preheat_job.yml"
+        file_exist = File.exist?(preheat_job_file_path)
+        expect(file_exist).to be_falsey
+      end
+    end
   end
 
   context "methods" do
@@ -36,6 +73,31 @@ describe Jets::Cfn::Builder do
 
       yes = Jets::Cfn::Builder.app_file?("app/models/post.rb")
       expect(yes).to be false
+    end
+
+    it "app_files" do
+      expect(Jets::Cfn::Builder.app_files).to include("app/controllers/posts_controller.rb")
+      expect(Jets::Cfn::Builder.app_files).to include("app/jobs/hard_job.rb")
+      expect(Jets::Cfn::Builder.app_files).to include("app/functions/hello.rb")
+
+      expect(Jets::Cfn::Builder.app_files).not_to include("app/models/post.rb")
+    end
+
+    context "prewarming enabled" do
+      before { Jets.config.prewarm.enable = true }
+
+      it "app_files includes preheat job" do
+        expect(Jets::Cfn::Builder.app_files).to include(a_string_ending_with("preheat_job.rb"))
+      end
+    end
+
+    context "prewarming disabled" do
+      before { Jets.config.prewarm.enable = false }
+
+      it "app_files does not include preheat job" do
+        expect(Jets.config.prewarm.enabled).to be_falsey
+        expect(Jets::Cfn::Builder.app_files).not_to include(a_string_ending_with("preheat_job.rb"))
+      end
     end
   end
 

--- a/spec/lib/jets/internal/preheat_job_spec.rb
+++ b/spec/lib/jets/internal/preheat_job_spec.rb
@@ -12,9 +12,16 @@ describe Jets::PreheatJob do
   end
 
   context "warm" do
-    it "calls all lambda functions with a prewarm request" do
-      allow(Jets::Preheat).to receive(:warm_all)
+    it "calls all lambda functions with a warm request" do
+      expect(Jets::Preheat).to receive(:warm_all)
       job.warm
+    end
+  end
+
+  context "prewarm!" do
+    it "calls all lambda functions with a prewarm! request" do
+      expect(Jets::Preheat).to receive(:warm_all)
+      Jets::PreheatJob.prewarm!
     end
   end
 end


### PR DESCRIPTION
This is a 🐞 bug fix.


- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fixes 3 issues with prewarming
1) The PreHeatJob is no longer included during stack build so prewarming never happens 
2) The PreHeatJob warm function was not scheduled with `rate` since the Jets 5 release
3) At the end of deploy the call to prewarm! has a spelling error and enqueues a :warn event instead of :warm

## Context

Prewarming was broken in Jets 5

## How to Test

Create a new Jets project and deploy it. Notice there is no lambda function for prewarming. Also notice at the end of the deployment it says prewarming but it actually does not trigger a call to warm.

## Version Changes

5.0.10
