### PR TITLE
Remove iam_class_policy warning from Jobs

### DIFF
--- a/lib/jets/lambda/dsl/warnings.rb
+++ b/lib/jets/lambda/dsl/warnings.rb
@@ -23,7 +23,7 @@ module Jets::Lambda::Dsl
     def class_iam_policy_unused_warning(managed=false)
       return unless Jets.config.cfn.build.controllers == "one_lambda_for_all_controllers"
       return if self.to_s == "ApplicationController" # ApplicationController not defined in job mode
-      return if self == Jets::PreheatJob
+      return if self.ancestors.include?(Jets::Job::Base)
 
       managed_prefix = managed ? "managed_" : ""
       puts <<~EOL.color(:yellow)

--- a/spec/lib/jets/cfn/builder/job_spec.rb
+++ b/spec/lib/jets/cfn/builder/job_spec.rb
@@ -1,4 +1,7 @@
 describe Jets::Cfn::Builder::Job do
+  require 'active_support/testing/stream'
+  include ActiveSupport::Testing::Stream
+
   let(:builder) do
     Jets::Cfn::Builder::Job.new(HardJob)
   end
@@ -13,6 +16,18 @@ describe Jets::Cfn::Builder::Job do
       expect(resources).to include("HardJobLiftEventsRule")
 
       expect(builder.template_path).to eq "#{Jets.build_root}/templates/app-hard_job.yml"
+    end
+  end
+
+  describe "class_iam_policy" do
+    it 'does not warn' do
+      output = capture(:stdout) do
+        class IamPolicyJob < ApplicationJob
+          class_iam_policy 'lambda:InvokeFunction'
+        end
+      end
+
+      expect(output).not_to include("WARNING: class_iam_policy")
     end
   end
 end


### PR DESCRIPTION
This is a 🐞 bug fix.

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Using class_iam_policy on Jobs works but prints out a warning which is intended for Controllers. This change allows PreHeatJob and ALL Jobs to use iam_class_policy.

## Context

The warning is REALLY useful for Controllers but unfortunately also warns for all Jobs except the PreheatJob.

## How to Test

Add `class_iam_policy` to any Job and when the Job class is loaded, notice you get a warning message. Or just run the job_spec.rb.

## Version Changes

5.0.x (10 currently)
