### PR TITLE
remove force_encoding that causes issues for international characters

### DIFF
--- a/lib/jets/overrides/lambda/marshaller.rb
+++ b/lib/jets/overrides/lambda/marshaller.rb
@@ -1,4 +1,4 @@
-require 'json'
+require "json"
 
 # Hack AwsLambda Ruby Runtime to fix .to_json issue collision with ActiveSupport.
 # To reproduce:
@@ -18,24 +18,14 @@ module AwsLambda
       def marshall_response(method_response)
         case method_response
         when StringIO, IO
-          [method_response, 'application/unknown']
+          [method_response, "application/unknown"]
         else
-          # Orignal method calls .to_json but this collides with ActiveSupport's to_json
-          # method_response.to_json # application/json is assumed
-          # https://stackoverflow.com/questions/18067203/ruby-to-json-issue-with-error-illegal-malformed-utf-8
-          if method_response.is_a?(Hash)
-            method_response.deep_transform_values! do |v|
-              if v.respond_to?(:force_encoding) && !v.frozen?
-                v.force_encoding("ISO-8859-1").encode("UTF-8")
-              else
-                v # IE: Integer
-              end
-            end
-          end
+          # Note: Removed previous code which did force_encoding("ISO-8859-1").encode("UTF-8")
+          # It caused issues with international characters.
+          # It does not seem like we need the force_encoding anymore.
           JSON.dump(method_response)
         end
       end
-
     end
   end
 end


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

The Jets AWS Lambda Marshaller override messes up international characters. 

**Screenshot before fix:**

<img width="761" alt="Screenshot 2024-03-20 at 10 19 15 AM" src="https://github.com/rubyonjets/jets/assets/4085/5701ff40-4127-4d8c-85e2-6ff3a7d5bfc9">

**Screenshot after fix:**

<img width="788" alt="Screenshot 2024-03-20 at 11 00 51 AM" src="https://github.com/rubyonjets/jets/assets/4085/64a62f32-37c1-4aeb-b6e6-e381adb22641">

## Context

Thanks to Brazil based user report.

I don't exactly remember why I added the original force encoding. So removing it with a note.

## How to Test

Deploy test project that user provided

https://github.com/VictorCostaOliveira/jets-error-demo

To to the /posts path.

The international characters should be right.

## Version Changes

Patch