### PR TITLE
lock dotenv gem to < 3

### DIFF
--- a/jets.gemspec
+++ b/jets.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "cfn_response"
   spec.add_dependency "cfn-status", ">= 0.5.0"
   spec.add_dependency "cli-format", ">= 0.4.0"
-  spec.add_dependency "dotenv"
+  spec.add_dependency "dotenv", '< 3'
   spec.add_dependency "dsl_evaluator", ">= 0.3.0" # for DslEvaluator.print_code
   spec.add_dependency "gems"
   spec.add_dependency "hashie"


### PR DESCRIPTION
Fixes #712  

This is a 🐞 bug fix.

- [X] The test suite passes (run `bundle exec rspec` to verify this)

## Summary
dotenv 3.0 introduces breaking changes which break `Jets::Dotenv.load!` in a way which causes the lamda function's environment to be corrupted on `jets deploy`

The test suite shows this failure so the necessary tests are already present.