### PR TITLE
fixes for dotenv 3.1

### DIFF
--- a/jets.gemspec
+++ b/jets.gemspec
@@ -1,30 +1,28 @@
-# coding: utf-8
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "jets/version"
 require "jets/rdoc"
 
 Gem::Specification.new do |spec|
-  spec.name          = "jets"
-  spec.version       = Jets::VERSION
-  spec.author        = "Tung Nguyen"
-  spec.email         = "tongueroo@gmail.com"
-  spec.summary       = "Ruby Serverless Framework"
-  spec.description   = "Jets is a framework that allows you to create serverless applications with a beautiful language: Ruby. It includes everything required to build and deploy an application.  Jets leverages the power of Ruby to make serverless joyful for everyone."
-  spec.homepage      = "https://rubyonjets.com"
-  spec.license       = "MIT"
+  spec.name = "jets"
+  spec.version = Jets::VERSION
+  spec.author = "Tung Nguyen"
+  spec.email = "tongueroo@gmail.com"
+  spec.summary = "Ruby Serverless Framework"
+  spec.description = "Jets is a framework that allows you to create serverless applications with a beautiful language: Ruby. It includes everything required to build and deploy an application.  Jets leverages the power of Ruby to make serverless joyful for everyone."
+  spec.homepage = "https://rubyonjets.com"
+  spec.license = "MIT"
 
-  spec.required_ruby_version = ['>= 2.7.0']
+  spec.required_ruby_version = [">= 2.7.0"]
   spec.rdoc_options += Jets::Rdoc.options
 
-  vendor_files       = Dir.glob("vendor/**/*")
-  gem_files          = `git -C "#{File.dirname(__FILE__)}" ls-files -z`.split("\x0").reject do |f|
+  vendor_files = Dir.glob("vendor/**/*")
+  gem_files = `git -C "#{File.dirname(__FILE__)}" ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features|docs)/})
   end
-  spec.files         = gem_files + vendor_files
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.files = gem_files + vendor_files
+  spec.bindir = "exe"
+  spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_dependency "actionmailer", "~> 7.0.8"
@@ -50,7 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "cfn_response"
   spec.add_dependency "cfn-status", ">= 0.5.0"
   spec.add_dependency "cli-format", ">= 0.4.0"
-  spec.add_dependency "dotenv"
+  spec.add_dependency "dotenv", ">= 3.1"
   spec.add_dependency "dsl_evaluator", ">= 0.3.0" # for DslEvaluator.print_code
   spec.add_dependency "gems"
   spec.add_dependency "hashie"

--- a/lib/jets/dotenv.rb
+++ b/lib/jets/dotenv.rb
@@ -1,23 +1,29 @@
-require 'dotenv'
+require "dotenv"
 
 class Jets::Dotenv
-  def self.load!(remote=false)
+  def self.load!(remote = false)
     new(remote).load!
   end
 
-  def initialize(remote=false)
-    @remote = ENV['JETS_ENV_REMOTE'] || remote
+  def initialize(remote = false)
+    @remote = ENV["JETS_ENV_REMOTE"] || remote
   end
 
+  # @@vars cache to prevent multiple calls to Ssm
+  # Tricky note: The cache also prevents the second call to Dotenv.load from
+  # returning {} vars. Dotenv 3.0 will not return the vars if it has already been loaded
+  # in the ENV. We want this side-effect due to the new way Dotenv 3.0 works.
+  @@vars = nil
   def load!
+    return @@vars if @@vars
     return if on_aws? # this prevents ssm calls if used in dotenv files
     vars = ::Dotenv.load(*dotenv_files)
-    Ssm.new(vars).interpolate!
+    @@vars = Ssm.new(vars).interpolate!
   end
 
   def on_aws?
-    return true if ENV['ON_AWS']
-    !!ENV['_HANDLER'] # https://docs.aws.amazon.com/lambda/latest/dg/lambda-environment-variables.html
+    return true if ENV["ON_AWS"]
+    !!ENV["_HANDLER"] # https://docs.aws.amazon.com/lambda/latest/dg/lambda-environment-variables.html
   end
 
   # dotenv files with the following precedence:
@@ -30,17 +36,16 @@ class Jets::Dotenv
   # - .env - The original (lowest)
   #
   def dotenv_files
-    files = [
-      root.join(".env"),
-      (root.join(".env.local") unless (Jets.env.test? || @remote)),
-      root.join(".env.#{Jets.env}"),
-      (root.join(".env.#{Jets.env}.local") unless @remote),
-    ]
+    files = []
+
+    files << files << root.join(".env.#{Jets.env}.#{Jets.extra}") if Jets.extra
     files << root.join(".env.#{Jets.env}.remote") if @remote
-    if Jets.extra
-      files << root.join(".env.#{Jets.env}.#{Jets.extra}")
-    end
-    files.compact
+    files << root.join(".env.#{Jets.env}.local") unless @remote
+    files << root.join(".env.#{Jets.env}")
+    files << root.join(".env.local") unless Jets.env.test? || @remote
+    files << root.join(".env")
+
+    files.compact.map(&:to_s)
   end
 
   def root


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fixes for Dotenv 3.0. Dotenv 3.0 made some breaking changes in order to make some good improvements. See it's changelog: https://github.com/bkeepers/dotenv/blob/main/Changelog.md

Users have reported this and have been able to workaround it by pinning dotenv to 2 See #712 

Also, there's a related PR #716 Totally get taking the approach to pin to lower versions. I've done it myself when there's a time-crunch.

This PR upgrades Jets so it works with the newer Dotenv 3.0 version and requires it. This will mean that users who have already pinned dotenv 2 in their Gemfile to remove it.

Eventually, found that older versions of gems become vaporware. Maintainers have other things in life than trying to keep old versions working 🤣

Some notes/thoughts about gem version pinning: 

* I wanted to note that Jets does not pin to strict versions in the gemspec because there are some advantages to this.
* This allows users to control and handle pinning. This can get them out of binds when needed. I've seen too many gems over time pins to old versions, and then it eventually becomes impossible for the bundler to resolve the gem dependency graph due to pins of versions that are too old. 
* I've found that pinning in the gemspec to a `>=` greater version requirement works better. Learned it the hard way by using `~>` previously and causing issues with that.
* Using `>=` allows users to have still enough control over gem versions in their `Gemfile.

Some notes about dotenv 3.0 behavior:

* The ordering of the files are in reverse now. This is part of the PR fix.
* It won't load env vars that are already loaded more aggressively. It's a nice performance optimization. This is why we need a `@@vars` cache now.

## Context

Closes #712 #716

## How to Test

Create and deploy a Jets demo app.

## Version Changes

Patch