### PR TITLE
Update docs link in status.rb

### DIFF
--- a/lib/jets/cfn/status.rb
+++ b/lib/jets/cfn/status.rb
@@ -17,7 +17,7 @@ module Jets::Cfn
         and can be used to resolve the issue.
         Example of checking the CloudFormation console:
 
-            https://rubyonjets.com/docs/debugging/cloudformation/
+            https://docs.rubyonjets.com/docs/debug/cloudformation/
 
       EOL
 


### PR DESCRIPTION
This replaces a broken documentation link with a working link to a page covering the subject.

<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
This is a 🧐 documentation change.

*NOTE:* I marked this as a documentation change as well as a bug fix because it's a change to an error message.

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

*NOTE:* I would mark the test suites as passing, but there are certain tests that fail for me even on master:

```
Failures:

  1) Jets::Dotenv#load! ignores *.local files when JETS_ENV_REMOTE=1
     Failure/Error: expect(env["ONLY_REMOTE"]).to eq "1"

       expected: "1"
            got: nil

       (compared using ==)
     # ./spec/lib/jets/dotenv_spec.rb:10:in `block (3 levels) in <top (required)>'

  2) Jets::Dotenv#load! replaces ssm:<relative-path> with SSM parameters prefixed with /<app-name>/<jets-env>/
     Failure/Error: expect(env.fetch("AUTENTICATED_URL")).to eq value

     KeyError:
       key not found: "AUTENTICATED_URL"
     # ./spec/lib/jets/dotenv_spec.rb:31:in `fetch'
     # ./spec/lib/jets/dotenv_spec.rb:31:in `block (3 levels) in <top (required)>'

  3) Jets::Dotenv#load! replaces ssm:/<absolute-path> with SSM parameters from the provided path
     Failure/Error: expect(env.fetch("ABSOLUTE_VARIABLE")).to eq value

     KeyError:
       key not found: "ABSOLUTE_VARIABLE"
     # ./spec/lib/jets/dotenv_spec.rb:54:in `fetch'
     # ./spec/lib/jets/dotenv_spec.rb:54:in `block (3 levels) in <top (required)>'

  4) Jets::Dotenv#load! aborts the process with a helpful error if an SSM parameter is not found at AWS
     Failure/Error:
       expect { Jets::Dotenv.new.load! }
         .to raise_error(SystemExit)
         .and output(/Error loading/).to_stderr

          expected SystemExit but nothing was raised

       ...and:

          expected block to output /Error loading/ to stderr, but output nothing
       Diff for (output /Error loading/ to stderr):
       @@ -1 +1 @@
       -/Error loading/
       +""

     # ./spec/lib/jets/dotenv_spec.rb:66:in `block (3 levels) in <top (required)>'

Finished in 1.84 seconds (files took 0.74176 seconds to load)
490 examples, 4 failures
```

## Summary

This updates a broken link in an error message that I've seen when my CloudFormation builds have thrown errors.

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

N/A

## How to Test

You need to make a CloudFormation build fail, then click on the documentation link in the error message. I figured that writing a spec or a demo app might be overkill for something like this, but please let me know what you think.


## Version Changes

v5.0.13

