### PR TITLE
Sets config.cache_classes to true in test env

### DIFF
--- a/lib/jets/generators/overrides/app/templates/config/environments/test.rb.tt
+++ b/lib/jets/generators/overrides/app/templates/config/environments/test.rb.tt
@@ -1,5 +1,5 @@
 Jets.application.configure do
-  config.cache_classes = false
+  config.cache_classes = true
   config.eager_load = ENV["CI"].present?
   config.cache_store = :null_store
 


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

I need a little help getting this pull request up to snuff with the standards of this project because I'm editing a template used for the configuration of new apps. I'm not sure what sort of automated tests you want for something like this. Do you want me to try adding the config change that I've already added in the template to `spec/fixtures/demo/config/environments/test.rb`.

Also, while this pull request hasn't made any new tests fail for me, I also am strangely unable to get tests passing on master. I've included test results from master and from my branch for comparison purposes. I can create a support forum thread about this issue after creating this pull request, if you'd like. I'm running Ruby 3.2.3 on macOS 14.4.1 (23E224), and my master branch is currently at 82796a7eb1516b477dd8e9f3549ac38e33b44e54.

<details>
 <summary>Tests failing on master</summary>


Failures:

  1) Jets::Dotenv#load! ignores *.local files when JETS_ENV_REMOTE=1
     Failure/Error: expect(env["ONLY_REMOTE"]).to eq "1"

       expected: "1"
            got: nil

       (compared using ==)
     # ./spec/lib/jets/dotenv_spec.rb:10:in `block (3 levels) in <top (required)>'

  2) Jets::Dotenv#load! replaces ssm:<relative-path> with SSM parameters prefixed with /<app-name>/<jets-env>/
     Failure/Error: expect(env.fetch("AUTENTICATED_URL")).to eq value

     KeyError:
       key not found: "AUTENTICATED_URL"
     # ./spec/lib/jets/dotenv_spec.rb:31:in `fetch'
     # ./spec/lib/jets/dotenv_spec.rb:31:in `block (3 levels) in <top (required)>'

  3) Jets::Dotenv#load! replaces ssm:/<absolute-path> with SSM parameters from the provided path
     Failure/Error: expect(env.fetch("ABSOLUTE_VARIABLE")).to eq value

     KeyError:
       key not found: "ABSOLUTE_VARIABLE"
     # ./spec/lib/jets/dotenv_spec.rb:54:in `fetch'
     # ./spec/lib/jets/dotenv_spec.rb:54:in `block (3 levels) in <top (required)>'

  4) Jets::Dotenv#load! aborts the process with a helpful error if an SSM parameter is not found at AWS
     Failure/Error:
       expect { Jets::Dotenv.new.load! }
         .to raise_error(SystemExit)
         .and output(/Error loading/).to_stderr

          expected SystemExit but nothing was raised

       ...and:

          expected block to output /Error loading/ to stderr, but output nothing
       Diff for (output /Error loading/ to stderr):
       @@ -1 +1 @@
       -/Error loading/
       +""
     # ./spec/lib/jets/dotenv_spec.rb:66:in `block (3 levels) in <top (required)>'

Finished in 1.89 seconds (files took 0.73701 seconds to load)
490 examples, 4 failures

Failed examples:

rspec ./spec/lib/jets/dotenv_spec.rb:8 # Jets::Dotenv#load! ignores *.local files when JETS_ENV_REMOTE=1
rspec ./spec/lib/jets/dotenv_spec.rb:13 # Jets::Dotenv#load! replaces ssm:<relative-path> with SSM parameters prefixed with /<app-name>/<jets-env>/
rspec ./spec/lib/jets/dotenv_spec.rb:35 # Jets::Dotenv#load! replaces ssm:/<absolute-path> with SSM parameters from the provided path
rspec ./spec/lib/jets/dotenv_spec.rb:58 # Jets::Dotenv#load! aborts the process with a helpful error if an SSM parameter is not found at AWS
</details>

<details>
 <summary>Tests failing on stubbing-fix</summary>

Failures:

  1) Jets::Dotenv#load! ignores *.local files when JETS_ENV_REMOTE=1
     Failure/Error: expect(env["ONLY_REMOTE"]).to eq "1"

       expected: "1"
            got: nil

       (compared using ==)
     # ./spec/lib/jets/dotenv_spec.rb:10:in `block (3 levels) in <top (required)>'

  2) Jets::Dotenv#load! replaces ssm:<relative-path> with SSM parameters prefixed with /<app-name>/<jets-env>/
     Failure/Error: expect(env.fetch("AUTENTICATED_URL")).to eq value

     KeyError:
       key not found: "AUTENTICATED_URL"
     # ./spec/lib/jets/dotenv_spec.rb:31:in `fetch'
     # ./spec/lib/jets/dotenv_spec.rb:31:in `block (3 levels) in <top (required)>'

  3) Jets::Dotenv#load! replaces ssm:/<absolute-path> with SSM parameters from the provided path
     Failure/Error: expect(env.fetch("ABSOLUTE_VARIABLE")).to eq value

     KeyError:
       key not found: "ABSOLUTE_VARIABLE"
     # ./spec/lib/jets/dotenv_spec.rb:54:in `fetch'
     # ./spec/lib/jets/dotenv_spec.rb:54:in `block (3 levels) in <top (required)>'

  4) Jets::Dotenv#load! aborts the process with a helpful error if an SSM parameter is not found at AWS
     Failure/Error:
       expect { Jets::Dotenv.new.load! }
         .to raise_error(SystemExit)
         .and output(/Error loading/).to_stderr

          expected SystemExit but nothing was raised

       ...and:

          expected block to output /Error loading/ to stderr, but output nothing
       Diff for (output /Error loading/ to stderr):
       @@ -1 +1 @@
       -/Error loading/
       +""
     # ./spec/lib/jets/dotenv_spec.rb:66:in `block (3 levels) in <top (required)>'

Finished in 1.95 seconds (files took 0.80936 seconds to load)
490 examples, 4 failures

Failed examples:

rspec ./spec/lib/jets/dotenv_spec.rb:8 # Jets::Dotenv#load! ignores *.local files when JETS_ENV_REMOTE=1
rspec ./spec/lib/jets/dotenv_spec.rb:13 # Jets::Dotenv#load! replaces ssm:<relative-path> with SSM parameters prefixed with /<app-name>/<jets-env>/
rspec ./spec/lib/jets/dotenv_spec.rb:35 # Jets::Dotenv#load! replaces ssm:/<absolute-path> with SSM parameters from the provided path
rspec ./spec/lib/jets/dotenv_spec.rb:58 # Jets::Dotenv#load! aborts the process with a helpful error if an SSM parameter is not found at AWS
</details>

## Summary

<!--
Provide a description of what your pull request changes.
-->

This corrects the `cache_classes` setting in the template for test environment files.

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

This fix addresses issue #721.

## How to Test

<!--
Please provide instructions on how to test the fix. This speeds up reviewing the PR. If testing requires a demo Jets project, please provide an example repo.
-->

1. Create a new API Jets app.
2. Copy the routes, controller, utility class, and tests from my [example app](https://github.com/greveritt/jets-class-caching-error-demo) to the new Jets app.
  - `app/controllers/demo_controller.rb`
  - `app/utilities/demo_utility.rb`
  - `spec/controllers/demo_controller_spec.rb`
  - `config/routes.rb`
3. Run `bundle exec rspec spec/controllers/demo_controller_spec.rb`

This works on my machine.

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->

Patch (unless this breaks something, of course)
