### PR TITLE
fix prewarming post deploy

### DIFF
--- a/engines/internal/app/jobs/jets/preheat_job.rb
+++ b/engines/internal/app/jobs/jets/preheat_job.rb
@@ -36,11 +36,12 @@ class Jets::PreheatJob < Jets::Job::Base
     end
   end
 
-private
+  private
+
   # Usually: jets-preheat_job-warm unless JETS_RESET=1, in that case need to lookup the function name
   def warm_function_name
     # Return early to avoid lookup call normally
-    return "jets-preheat_job-warm" unless ENV['JETS_RESET'] == "1"
+    return "jets-preheat_job-warm" unless ENV["JETS_RESET"] == "1"
 
     parent_stack = cfn.describe_stack_resources(stack_name: Jets::Names.parent_stack_name)
     preheat_stack = parent_stack.stack_resources.find do |resource|
@@ -58,11 +59,6 @@ private
   def call_options(quiet)
     options = {}
     options.merge!(mute: true, mute_output: true) if quiet
-    # All the methods in this Job class leads to Jets::Commands::Call.
-    # This is true for the Jets::Preheat.warm_all also.
-    # These jobs delegate out to Lambda function calls. We do not need/want
-    # the invocation type: RequestResponse in this case.
-    options.merge!(invocation_type: "Event")
     options
   end
 end


### PR DESCRIPTION
* preheat invocation_type RequestResponse

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fixes the prewarming call post `jets deploy`.  Using `invocation_type: RequestResponse` so there's a `resp.payload` from the `resp = lambda_client.invoke` call.

Future versions of Jets uses a RequestResponse invocation time also because the extra resp.payload data is useful for printing and debugging.

## Context

Reported in the community forums https://community.boltops.com/t/cant-deploy-basic-api/1160/5

## How to Test

Go through one of the Jets learn guides

## Version Changes

Patch