### PR TITLE
dont show queue url by default

### DIFF
--- a/lib/jets/cli.rb
+++ b/lib/jets/cli.rb
@@ -176,6 +176,7 @@ module Jets
 
     desc "url", "App url"
     format_option(default: "space")
+    option :all, type: :boolean, desc: "Show all urls including queue urls"
     def url
       Url.new(options).run
     end

--- a/lib/jets/cli/url.rb
+++ b/lib/jets/cli/url.rb
@@ -34,6 +34,7 @@ class Jets::CLI
         acc.merge!(endpoint[:name] => endpoint[:url])
       end
       data.delete_if { |k, v| v.nil? } # remove nil values
+      data.delete_if { |k| k.include?("queue_url") } unless @options[:all]
       data
     end
     memoize :data


### PR DESCRIPTION
- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Add `jets url --all` option. Don't show the deployed SQS queue urls by default.

## Context

https://community.boltops.com/t/1-sqs-queue-lambda-per-job/1189/3

Note: This does require upgrading `jets-rails` to at least 1.1.0

Related: https://github.com/rubyonjets/jets-rails/pull/14

## How to Test

Deploy multiple queues.

## Version Changes

Patch