### PR TITLE
scheduler translate scheduler.schedule key

### DIFF
--- a/lib/jets/cli/schedule/translate.rb
+++ b/lib/jets/cli/schedule/translate.rb
@@ -17,9 +17,9 @@ class Jets::CLI::Schedule
       # Currently only sidekiq is supported
       sidekiq = YAML.load_file("config/sidekiq.yml")
       sidekiq = ActiveSupport::HashWithIndifferentAccess.new(sidekiq)
-      schedule = sidekiq[:schedule]
+      schedule = sidekiq.dig(:scheduler, :schedule) || sidekiq[:schedule]
       unless schedule
-        log.error "config/sidekiq.yml does not have a schedule key. Nothing to translate."
+        log.error "config/sidekiq.yml does not have a scheduler.schedule key. Nothing to translate."
         return false
       end
 


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Support config/sidekiq.yml `scheduler.schedule` in for `jets scheduler:translate`

## Version Changes

Patch