### PR TITLE
Require fugit >= 1.11.1

### DIFF
--- a/jets.gemspec
+++ b/jets.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "cli-format", ">= 0.6.1"
   spec.add_dependency "dotenv", ">= 3.1"
   spec.add_dependency "dsl_evaluator", ">= 0.3.0" # for DslEvaluator.print_code
-  spec.add_dependency "fugit"
+  spec.add_dependency "fugit", "~> 1.11", ">= 1.11.1"
   spec.add_dependency "gems"
   spec.add_dependency "hashie"
   spec.add_dependency "kramdown"


### PR DESCRIPTION
https://github.com/floraison/fugit/issues/104

Prevent Fugit::Nat.parse choking on large input, peg at 256 chars

```ruby
spec.add_dependency "fugit", "~> 1.11", ">= 1.11.1"
```

Which requires fugit from 1.11.0 to 2.x not included and at least 1.11.1

---


<!-- This is a 🐞 bug fix. -->
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->
This is a dependency upgrade.

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

> - [ ] I've added tests (if it's a bug, feature or enhancement)
> - [ ] I've adjusted the documentation (if it's a feature or enhancement)
> - [ ] The test suite passes (run `bundle exec rspec` to verify this)

Sorry, I haven't done any of this.

