### PR TITLE
git commit check

### DIFF
--- a/lib/jets/git/git_cli.rb
+++ b/lib/jets/git/git_cli.rb
@@ -1,7 +1,7 @@
 module Jets::Git
   module GitCli
     def git?
-      git_folder? && git_installed?
+      git_folder? && git_installed? && git_commits?
     end
 
     def git_folder?
@@ -10,6 +10,11 @@ module Jets::Git
 
     def git_installed?
       system "type git > /dev/null 2>&1"
+    end
+
+    # Edge case: git init but no commits yet
+    def git_commits?
+      system "git rev-parse HEAD >/dev/null 2>&1"
     end
 
     def git(args, on_error: :nil)


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Super edge case, when the project has a `git init` repo but **no commits**  yet, it'll show some errors as Jets tries to get get git sha info that's unavailable. This fixes that.

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

## How to Test

<!--
Please provide instructions on how to test the fix. This speeds up reviewing the PR. If testing requires a demo Jets project, please provide an example repo.
-->


## Version Changes

Patch