### PR TITLE
jets login prompt message when likely ci env

### DIFF
--- a/lib/jets/api/config.rb
+++ b/lib/jets/api/config.rb
@@ -46,7 +46,17 @@ module Jets::Api
         You can get an api key from www.rubyonjets.com
       EOL
       print "Please provide your api key: "
-      $stdin.gets.strip
+      input = $stdin.gets
+      if input.nil?
+        # puts "No input provided. Exiting. Are you running this in a non-TTY environment?"
+        puts <<~EOL
+          Error: No input provided. Exiting.
+          This might be running inside a non-TTY environment like a script or a CI/CD pipeline.
+          Are you sure the API key was set?
+        EOL
+        exit 1
+      end
+      input.strip
     end
 
     # interface method: do not remove


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

When users are running `jets deploy` in a CI pipeline and they run `jets login $TOKEN` and TOKEN is not set, this provides a more helpful message.

## How to Test

Use a test script like this

prompt.sh

```sh
#!/usr/bin/env bash
# force non-TTY with exec
exec jets login
```

## Version Changes

Patch